### PR TITLE
i18n

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="%svelte.lang%">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <link rel="manifest" href="%svelte.assets%/manifest.json" />
     <link rel="shortcut icon" href="%svelte.assets%/favicon.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="%svelte.assets%/apple-touch-icon.png" />
     %svelte.head%
   </head>
   <body>

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,17 +1,20 @@
-import { getHostLanguageFromSearch, locales } from '$lib/i18n/i18n';
+import { locales } from '$lib/i18n/i18n';
 import type { Handle } from '@sveltejs/kit';
 export const handle: Handle = async function handle({ event, resolve }) {
   // Search locale based on hl query string
-  const hl = getHostLanguageFromSearch(event.url.search);
+  const hl = event.url.searchParams.get('hl');
   const hlLocale = getHostLanguageLocale(hl);
   // Search locale based on accept-language header
   const accLang = event.request.headers.get('accept-language') ?? '';
   const prefLocale = getUserPreferredLocale(accLang);
-  if (!hlLocale && prefLocale !== locales[0]) {
+  if (!hl && prefLocale !== locales[0]) {
+    const p = event.url.searchParams;
+    p.set('hl', prefLocale);
+    const location = event.url.pathname + '?' + p.toString();
     const r = new Response('', {
       status: 302,
       headers: {
-        location: '/?hl=' + prefLocale,
+        location,
       },
     });
     return r;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,49 @@
+import { getHostLanguageFromSearch, locales } from '$lib/i18n/i18n';
+import type { Handle } from '@sveltejs/kit';
+export const handle: Handle = async function handle({ event, resolve }) {
+  // Search locale based on hl query string
+  const hl = getHostLanguageFromSearch(event.url.search);
+  const hlLocale = getHostLanguageLocale(hl);
+  // Search locale based on accept-language header
+  const accLang = event.request.headers.get('accept-language') ?? '';
+  const prefLocale = getUserPreferredLocale(accLang);
+  if (!hlLocale && prefLocale !== locales[0]) {
+    const r = new Response('', {
+      status: 302,
+      headers: {
+        location: '/?hl=' + prefLocale,
+      },
+    });
+    return r;
+  }
+  const response = await resolve(event, {
+    ssr: true,
+    transformPage: ({ html }) => html.replace('%svelte.lang%', hlLocale || 'en'),
+  });
+  return response;
+};
+
+function getHostLanguageLocale(hl: string) {
+  let locale: string;
+  for (const l of locales) {
+    if (l === hl) {
+      locale = l;
+      return locale;
+    }
+  }
+  return locale;
+}
+
+function getUserPreferredLocale(accLang: string) {
+  let userPreferredLocale = 'en';
+  const accLangList = accLang.split(',');
+  for (const accL of accLangList) {
+    for (const l of locales) {
+      if (accL.startsWith(l)) {
+        userPreferredLocale = l;
+        return userPreferredLocale;
+      }
+    }
+  }
+  return userPreferredLocale;
+}

--- a/src/lib/content/EmailContent.svelte
+++ b/src/lib/content/EmailContent.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-  import { decryptMessage, getEncryptionSecret, isProbablyEncrypted } from './encryption';
+  import { decryptMessageWithPrompt, getEncryptionSecret, isProbablyEncrypted } from './encryption';
   import type { HTMLElementEvent } from '../core/types';
+  import { getContext } from 'svelte';
+  import type { TranslationFunction } from '$lib/i18n/translation';
   export let onChange: (content: string, aes: boolean) => void;
   export let isLoading = false;
   export let messageContent = '';
   export let enableClientAES = false;
+  const tr = getContext<TranslationFunction>('tr');
   let autoToggleClientAES = false;
   const maxRows = 20;
   const minRows = 12;
@@ -14,7 +17,7 @@
   const handleChange = (content: string, aes: boolean) => {
     autoToggleClientAES = false;
     if (aes) {
-      content = decryptMessage(content) || content;
+      content = decryptMessageWithPrompt(content, tr) || content;
     }
     onChange(content, aes);
   };
@@ -27,7 +30,7 @@
     toggleShow = !toggleShow;
   }
   const handleFocus = () => (autoToggleShow = false);
-  const placeholder = 'Message is encrypted by default';
+  const placeholder = tr('contentPlaceholder');
   $: {
     if (autoToggleShow) {
       toggleShow = messageContent.length === 0;
@@ -61,13 +64,13 @@
   >
   <div class="toggle aes" on:click={handleAESToggle}>
     <div>client-aes:</div>
-    <div>{enableClientAES ? 'on' : 'off'}</div>
+    <div>{enableClientAES ? tr('on') : tr('off')}</div>
   </div>
   <div class="toggle show" on:click={handleShowToggle}>
-    {toggleShow ? 'hide' : 'show'}
+    {toggleShow ? tr('hide') : tr('show')}
   </div>
   {#if isLoading}
-    <div class="loading">Loading...</div>
+    <div class="loading">{tr('loading')}</div>
   {/if}
 </div>
 

--- a/src/lib/content/EmailContent.svelte
+++ b/src/lib/content/EmailContent.svelte
@@ -62,12 +62,14 @@
     style="filter: {toggleShow ? 'none' : 'blur(5px)'}; opacity: {isLoading ? '0' : '1'}"
     >{messageContent}</textarea
   >
-  <div class="toggle aes" on:click={handleAESToggle}>
-    <div>client-aes:</div>
-    <div>{enableClientAES ? tr('on') : tr('off')}</div>
-  </div>
-  <div class="toggle show" on:click={handleShowToggle}>
-    {toggleShow ? tr('hide') : tr('show')}
+  <div class="toggleWrapper">
+    <div class="toggle aes" on:click={handleAESToggle}>
+      <div>client-aes:</div>
+      <div>{enableClientAES ? tr('on') : tr('off')}</div>
+    </div>
+    <div class="toggle show" on:click={handleShowToggle}>
+      {toggleShow ? tr('hide') : tr('show')}
+    </div>
   </div>
   {#if isLoading}
     <div class="loading">{tr('loading')}</div>
@@ -80,11 +82,15 @@
     margin-bottom: 30px;
     border-bottom: 1px solid var(--color-lightgrey);
   }
-  .toggle {
+  .toggleWrapper {
     position: absolute;
+    right: 2px;
+    bottom: -24px;
+    display: flex;
+  }
+  .toggle {
     padding: 4px 6px;
     text-align: center;
-    bottom: -24px;
     cursor: pointer;
     background-color: var(--color-darkgrey);
     text-transform: uppercase;
@@ -97,12 +103,11 @@
     justify-content: space-between;
   }
   .toggle.aes {
-    width: 108px;
-    right: 52px;
+    min-width: 108px;
+    margin-right: 4px;
   }
   .toggle.show {
-    width: 48px;
-    right: 2px;
+    min-width: 48px;
     justify-content: center;
   }
   .toggle div:nth-child(2) {

--- a/src/lib/content/encryption.ts
+++ b/src/lib/content/encryption.ts
@@ -1,4 +1,5 @@
 import { STORAGE_ENCRYPTION_SECRET } from '$lib/core/storageKeys';
+import type { TranslationFunction } from '$lib/i18n/translation';
 import AES from 'crypto-js/aes.js';
 import cryptoJS_UTF8 from 'crypto-js/enc-utf8.js';
 
@@ -16,7 +17,7 @@ const defaultConfig: EncryptionConfig = {
 const secretLength = 32;
 const encryptPrefixText = `${defaultConfig.cipher}.${defaultConfig.encoding}:`;
 
-export function encryptMessage(text: string) {
+export function encryptMessageWithPrompt(text: string, tr: TranslationFunction) {
   // Prevent double encryption
   if (isProbablyEncrypted(text) || text === '') {
     return text;
@@ -28,11 +29,7 @@ export function encryptMessage(text: string) {
       secret = randomString(secretLength);
       localStorage.setItem(STORAGE_ENCRYPTION_SECRET, secret);
     }
-    prompt(
-      'Please make a copy of this secret and send it to the recipients. ' +
-        'No one will be able to decrypt the message if you lost it.',
-      secret,
-    );
+    prompt(tr('backupSecret'), secret);
     const encryptedText = encryptPrefixText + AES.encrypt(text, secret).toString();
     return encryptedText;
   } catch (err) {
@@ -41,7 +38,7 @@ export function encryptMessage(text: string) {
   }
 }
 
-export function decryptMessage(text: string) {
+export function decryptMessageWithPrompt(text: string, tr: TranslationFunction) {
   // Prevent decrypting non encrypted text
   if (!isProbablyEncrypted(text)) {
     return text;
@@ -50,10 +47,7 @@ export function decryptMessage(text: string) {
     text = text.replace(encryptPrefixText, '');
     let secret = localStorage.getItem(STORAGE_ENCRYPTION_SECRET);
     if (!secret) {
-      secret = prompt(
-        'It seems like your message is encrypted. ' +
-          'Please enter your secret if you wish to decrypt it.',
-      );
+      secret = prompt(tr('provideSecret'));
       if (!secret) {
         return null;
       }

--- a/src/lib/core/Footer.svelte
+++ b/src/lib/core/Footer.svelte
@@ -1,7 +1,13 @@
+<script lang="ts">
+  import type { TranslationFunction } from '$lib/i18n/translation';
+  import { getContext } from 'svelte';
+  const tr = getContext<TranslationFunction>('tr');
+</script>
+
 <footer>
   2018 - 2022
   <br />
-  sejiwo - source code:
+  sejiwo - {tr('sourceCode')}:
   <a target="_blank" rel="noopener noreferrer" href="https://github.com/asendia/legacy-web">
     web
   </a>

--- a/src/lib/core/urls.ts
+++ b/src/lib/core/urls.ts
@@ -1,1 +1,2 @@
 export const API_URL = 'https://asia-southeast1-monarch-public.cloudfunctions.net';
+export const WEB_URL = 'https://sejiwo.com';

--- a/src/lib/email/EmailListInput.svelte
+++ b/src/lib/email/EmailListInput.svelte
@@ -70,7 +70,7 @@
 </script>
 
 <div class="wrapper" on:click={handleWrapperClick}>
-  <div class="toText" style={labelText === 'To' ? '' : 'color: var(--color-lightgrey);'}>
+  <div class="toText" style={labelText === txtTo ? '' : 'color: var(--color-lightgrey);'}>
     {labelText}
   </div>
   {#each emailList as email, id}
@@ -109,7 +109,6 @@
     cursor: text;
     position: relative;
     box-sizing: border-box;
-    padding-left: 20px;
   }
   .wrapper:focus {
     outline-width: 1px;
@@ -118,9 +117,6 @@
     font-size: 14px;
     line-height: 16px;
     margin: 1px 5px 4px 0;
-    position: absolute;
-    left: 0;
-    top: 0;
   }
   .email {
     position: relative;

--- a/src/lib/email/EmailListInput.svelte
+++ b/src/lib/email/EmailListInput.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import type { HTMLElementEvent } from '$lib/core/types';
+  import type { TranslationFunction } from '$lib/i18n/translation';
+  import { getContext } from 'svelte';
   import { isValidEmail } from './emailValidator';
   export let onChange: (emailList: Array<string>) => void;
   export let isLoading = false;
   export let emailList: Array<string> = [];
   export const focus = () => inputText.focus();
-  const txtRecipients = 'Recipient emails';
-  const txtTo = 'To';
+  const tr = getContext<TranslationFunction>('tr');
+  const txtPlaceholder = tr('emailListPlaceholder');
+  const txtTo = tr('emailListTo');
   let showInput = false;
   let labelText = txtTo;
   let text = '';
@@ -43,7 +46,7 @@
     addEmail(text);
     if (emailList.length === 0 && text === '') {
       showInput = false;
-      labelText = txtRecipients;
+      labelText = txtPlaceholder;
     }
   }
   const createHandleDeleteEmail = (id: number) => () => deleteEmail(id);
@@ -92,7 +95,7 @@
 </div>
 <div class="customValidityWrapper">
   <div class="customValidity" style="opacity: {isInvalidInput ? '100%' : '0%'};">
-    Email address should conform to name@host.com
+    {tr('emailListValidity')}
   </div>
 </div>
 

--- a/src/lib/form/draft.ts
+++ b/src/lib/form/draft.ts
@@ -21,7 +21,11 @@ export function clearDraft() {
   sessionStorage.removeItem(STORAGE_MESSAGE_CONTENT);
 }
 
-export function consolidateDraft(emailReceivers: Array<string>, messageContent: string) {
+export function consolidateDraft(
+  emailReceivers: Array<string>,
+  messageContent: string,
+  confirmCallback: () => boolean,
+) {
   // Consolidate API response with user cache
   const cReceivers = getDraftEmailReceivers();
   const cContent = getDraftMessageContent();
@@ -40,14 +44,7 @@ export function consolidateDraft(emailReceivers: Array<string>, messageContent: 
       return false;
     })() || !(messageContent === '' || cContent === '' || messageContent === cContent);
   if (isConflicted) {
-    if (
-      !confirm(
-        'Data conflict, do you want to use data from the server instead?\nRecipients: ' +
-          emailReceivers.join(', ') +
-          '\nContent: ' +
-          messageContent,
-      )
-    ) {
+    if (!confirmCallback()) {
       emailReceivers = cReceivers;
       messageContent = cContent;
     }

--- a/src/lib/form/form.svelte
+++ b/src/lib/form/form.svelte
@@ -143,7 +143,7 @@
 <Button
   onClick={handleClickSubmit}
   disabled={disableSubmit}
-  text={tr('submit')}
+  text={tr('formSubmit')}
   variant={auth ? 'filled' : 'outlined'}
   style="display: block; width: 100%;"
 />

--- a/src/lib/i18n/SEO.svelte
+++ b/src/lib/i18n/SEO.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { WEB_URL } from '$lib/core/urls';
+  import { locales } from '$lib/i18n/i18n';
+  export let pathname: string;
+  export let locale: string;
+  let canonicalURL: string;
+  const alternateURLs = locales.map((loc, id) => {
+    const url = WEB_URL + pathname + (id === 0 ? '' : '?hl=' + loc);
+    if (loc === locale) {
+      canonicalURL = url;
+    }
+    return url;
+  });
+</script>
+
+{#each alternateURLs as url, id}
+  <link rel="alternate" hreflang={locales[id]} href={url} />
+{/each}
+<link rel="canonical" href={canonicalURL} />

--- a/src/lib/i18n/i18n.ts
+++ b/src/lib/i18n/i18n.ts
@@ -1,0 +1,26 @@
+import { initTranslation, type TranslationData } from './translation';
+
+export const locales = ['en', 'id'];
+
+export async function i18n(locale: string) {
+  let translationData: TranslationData;
+  switch (locale) {
+    case 'id': {
+      translationData = (await import('$lib/i18n/translationData_id')).translationData;
+      break;
+    }
+    case 'en':
+    default: {
+      locale = 'en';
+      translationData = (await import('$lib/i18n/translationData_en')).translationData;
+    }
+  }
+  const tr = initTranslation(translationData);
+  return { tr, locale };
+}
+
+export function getHostLanguageFromSearch(search: string) {
+  const p = new URLSearchParams(search);
+  const hl = p.get('hl');
+  return hl;
+}

--- a/src/lib/i18n/translation.ts
+++ b/src/lib/i18n/translation.ts
@@ -1,0 +1,16 @@
+export interface TranslationData {
+  [key: string]: string;
+}
+export interface TranslationFunction {
+  (key: string): string;
+}
+
+export function initTranslation(data: TranslationData) {
+  return function tr(key: string): string {
+    const str = data[key];
+    if (typeof str === 'string') {
+      return str;
+    }
+    return key;
+  } as TranslationFunction;
+}

--- a/src/lib/i18n/translationData_en.ts
+++ b/src/lib/i18n/translationData_en.ts
@@ -1,0 +1,39 @@
+import type { TranslationData } from './translation';
+
+export const translationData: TranslationData = {
+  // Index page
+  title: 'Sejiwo - Your testament in the cloud',
+  description: 'Sejiwo is a secure testament storage and delivery service',
+  subheading: 'Testament in the cloud',
+  welcome: 'Welcome',
+  login: 'login',
+  logout: 'logout',
+  emailListTo: 'To',
+  emailListPlaceholder: 'Recipient emails',
+  emailListValidity: 'Email address should conform to name@host.com',
+  contentPlaceholder: 'Message is encrypted by default',
+  show: 'show',
+  hide: 'hide',
+  on: 'on',
+  off: 'off',
+  loading: 'Loading...',
+  draftConflict: 'Data conflict, do you want to use data from the server instead?',
+  draftRecipients: 'Recipients',
+  draftContent: 'Content',
+  backupSecret:
+    'Please make a copy of this secret and send it to the recipients. ' +
+    'No one will be able to decrypt the message if you lost it.',
+  provideSecret:
+    'It seems like your message is encrypted. ' +
+    'Please enter your secret if you wish to decrypt it.',
+  authUndefined: 'You need to login first',
+  authExpired: 'Session expired, want to backup the content first?',
+  formSubmit: 'submit',
+  messageExtended: 'Message has been extended!',
+  messageUnsubscribed: 'Message has been unsubscribed!',
+  queryActionError: 'Probably you have already used this extension url. Redirect to home?',
+  scheduler_pt1: 'Send this message to recipients after',
+  scheduler_pt2: 'of inactivity. Every',
+  scheduler_pt3: 'a reminder will be sent to',
+  schedulerDays: 'days',
+};

--- a/src/lib/i18n/translationData_en.ts
+++ b/src/lib/i18n/translationData_en.ts
@@ -35,5 +35,7 @@ export const translationData: TranslationData = {
   scheduler_pt1: 'Send this message to recipients after',
   scheduler_pt2: 'of inactivity. Every',
   scheduler_pt3: 'a reminder will be sent to',
+  yourEmailPlaceholder: 'me',
   schedulerDays: 'days',
+  sourceCode: 'source code',
 };

--- a/src/lib/i18n/translationData_id.ts
+++ b/src/lib/i18n/translationData_id.ts
@@ -1,0 +1,41 @@
+import type { TranslationData } from './translation';
+
+export const translationData: TranslationData = {
+  // Index page
+  title: 'Sejiwo - Surat wasiat online',
+  description: 'Sejiwo adalah jasa pengiriman surat wasiat yang terpercaya',
+  subheading: 'Surat wasiat online',
+  welcome: 'Selamat datang',
+  login: 'masuk',
+  logout: 'keluar',
+  emailListTo: 'Kepada',
+  emailListPlaceholder: 'Email penerima',
+  emailListValidity: 'Alamat email yang benar: nama@domain.com',
+  contentPlaceholder: 'Pesan ter-enkripsi',
+  show: 'munculkan',
+  hide: 'sembunyikan',
+  on: 'on',
+  off: 'off',
+  loading: 'Menunggu...',
+  draftConflict: 'Konflik data, apakah ingin menggunakan data dari server?',
+  draftRecipients: 'Email penerima',
+  draftContent: 'Pesan',
+  backupSecret:
+    'Silahkan membuat copy dari kode berikut dan kirim secara aman ke penerima wasiat. ' +
+    'Jika kode hilang maka pesan ini tidak akan bisa dibaca.',
+  provideSecret:
+    'Silahkan masukan kode untuk membaca pesan.',
+  authUndefined: 'Silahkan login terlebih dahulu',
+  authExpired: 'Sesi berakhir, apakah Anda ingin menyalin data terlebih dahulu?',
+  formSubmit: 'simpan',
+  messageExtended: 'Pengiriman pesan berhasil ditunda',
+  messageUnsubscribed: 'Anda berhasil berhenti berlangganan',
+  queryActionError: 'Kembali ke halaman utama?',
+  scheduler_pt1: 'Kirim pesan ini jika Anda tidak aktif dalam',
+  scheduler_pt2: '. Untuk memberitahu bahwa Anda masih aktif, klik ' +
+    'link yang akan kami kirim setiap',
+  scheduler_pt3: 'ke',
+  yourEmailPlaceholder: 'email Anda',
+  schedulerDays: 'hari',
+  sourceCode: 'kode sumber',
+};

--- a/src/lib/i18n/translationData_id.ts
+++ b/src/lib/i18n/translationData_id.ts
@@ -23,8 +23,7 @@ export const translationData: TranslationData = {
   backupSecret:
     'Silahkan membuat copy dari kode berikut dan kirim secara aman ke penerima wasiat. ' +
     'Jika kode hilang maka pesan ini tidak akan bisa dibaca.',
-  provideSecret:
-    'Silahkan masukan kode untuk membaca pesan.',
+  provideSecret: 'Silahkan masukan kode untuk membaca pesan.',
   authUndefined: 'Silahkan login terlebih dahulu',
   authExpired: 'Sesi berakhir, apakah Anda ingin menyalin data terlebih dahulu?',
   formSubmit: 'simpan',
@@ -32,8 +31,8 @@ export const translationData: TranslationData = {
   messageUnsubscribed: 'Anda berhasil berhenti berlangganan',
   queryActionError: 'Kembali ke halaman utama?',
   scheduler_pt1: 'Kirim pesan ini jika Anda tidak aktif dalam',
-  scheduler_pt2: '. Untuk memberitahu bahwa Anda masih aktif, klik ' +
-    'link yang akan kami kirim setiap',
+  scheduler_pt2:
+    '. Untuk memberitahu bahwa Anda masih aktif, klik ' + 'link yang akan kami kirim setiap',
   scheduler_pt3: 'ke',
   yourEmailPlaceholder: 'email Anda',
   schedulerDays: 'hari',

--- a/src/lib/query-string/queryStringHandler.ts
+++ b/src/lib/query-string/queryStringHandler.ts
@@ -1,7 +1,11 @@
 import { extendMessage, unsubscribeMessage } from '$lib/query-string/queryStringFetcher';
 
 // Query string visit for unsubsribe & extend message
-export async function handleQueryVisit() {
+export async function handleQueryVisit(
+  messageExtendedAlert: string,
+  messageUnsubscribedAlert: string,
+  queryActionErrorAlert: string,
+) {
   const qs = new URLSearchParams(location.search);
   const action = qs.get('action');
   const secret = qs.get('secret');
@@ -12,20 +16,18 @@ export async function handleQueryVisit() {
       switch (action) {
         case 'extend-message':
           await extendMessage(id, secret);
-          alert('Message has been extended!');
+          alert(messageExtendedAlert);
           break;
         case 'unsubscribe-message':
           await unsubscribeMessage(id, secret);
-          alert('Message has been unsubscribed!');
+          alert(messageUnsubscribedAlert);
           break;
         default:
           throw new Error('Invalid action: ' + action);
       }
     } catch (err) {
       console.error(err);
-      redirectToHome = confirm(
-        'Probably you have already used this extension url. Redirect to home?',
-      );
+      redirectToHome = confirm(queryActionErrorAlert);
     }
     redirectToHome && location.replace('/');
   }

--- a/src/lib/schedule/Scheduler.svelte
+++ b/src/lib/schedule/Scheduler.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import type { HTMLElementEvent } from '$lib/core/types';
   import type { TranslationFunction } from '$lib/i18n/translation';
   import { getContext } from 'svelte';
-  export let emailCreator = 'me';
+  const tr = getContext<TranslationFunction>('tr');
+  import type { HTMLElementEvent } from '$lib/core/types';
   export let reminderIntervalDays: number;
   export let inactivePeriodDays: number;
   export let onChange: (value: number, type: 'reminder' | 'inactive') => void;
-  const tr = getContext<TranslationFunction>('tr');
+  export let emailCreator = tr('yourEmailPlaceholder');
   const inactivePeriodDaysOptions = [30, 60, 90];
   const reminderIntervalDaysOptions = [15, 30];
 

--- a/src/lib/schedule/Scheduler.svelte
+++ b/src/lib/schedule/Scheduler.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import type { HTMLElementEvent } from '$lib/core/types';
+  import type { TranslationFunction } from '$lib/i18n/translation';
+  import { getContext } from 'svelte';
   export let emailCreator = 'me';
   export let reminderIntervalDays: number;
   export let inactivePeriodDays: number;
   export let onChange: (value: number, type: 'reminder' | 'inactive') => void;
-
+  const tr = getContext<TranslationFunction>('tr');
   const inactivePeriodDaysOptions = [30, 60, 90];
   const reminderIntervalDaysOptions = [15, 30];
 
@@ -19,27 +21,28 @@
 </script>
 
 <div class="wrapper">
-  Send this message to recipients after
+  {tr('scheduler_pt1')}
   <select on:change={handleInactivePeriodChange}>
     {#each inactivePeriodDaysOptions as i}
       {#if i === inactivePeriodDays}
-        <option value={i} selected>{i} days</option>
+        <option value={i} selected>{i} {tr('schedulerDays')}</option>
       {:else}
-        <option value={i}>{i} days</option>
+        <option value={i}>{i} {tr('schedulerDays')}</option>
       {/if}
     {/each}
   </select>
-  of inactivity. Every
+  {tr('scheduler_pt2')}
   <select on:change={handleReminderIntervalChange}>
     {#each reminderIntervalDaysOptions as i}
       {#if i === reminderIntervalDays}
-        <option value={i} selected>{i} days</option>
+        <option value={i} selected>{i} {tr('schedulerDays')}</option>
       {:else}
-        <option value={i}>{i} days</option>
+        <option value={i}>{i} {tr('schedulerDays')}</option>
       {/if}
     {/each}
   </select>
-  a reminder will be sent to {emailCreator}.
+  {tr('scheduler_pt3')}
+  {emailCreator}.
 </div>
 
 <style>

--- a/src/lib/user/Login.svelte
+++ b/src/lib/user/Login.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import Button from '$lib/core/Button.svelte';
+  import type { TranslationFunction } from '$lib/i18n/translation';
   import { getAuthFromLocalStorage, logout, type AuthObject } from '$lib/user/auth';
-  import { onMount } from 'svelte';
+  import { getContext, onMount } from 'svelte';
   import { fetchAuthorizeUser } from './userFetcher';
+  const tr = getContext<TranslationFunction>('tr');
   let auth: AuthObject;
-  let message = 'Testament in the cloud';
+  let message = tr('subheading');
   let disabled = true;
   let color: 'primary' | 'secondary' = 'primary';
-  let text = 'login';
+  let text = tr('login');
   const enableButton = () => (disabled = false);
   onMount(() => {
     addEventListener('popstate', enableButton);
@@ -37,12 +39,12 @@
   }
   $: {
     if (auth) {
-      message = 'Welcome, ' + (auth.user_metadata?.full_name ?? auth.email);
+      message = tr('welcome') + ', ' + (auth.user_metadata?.full_name ?? auth.email);
       color = 'secondary';
-      text = 'logout';
+      text = tr('logout');
     } else {
       color = 'primary';
-      text = 'login';
+      text = tr('login');
     }
     disabled = false;
   }

--- a/src/lib/user/auth.ts
+++ b/src/lib/user/auth.ts
@@ -1,6 +1,6 @@
 import { throwIfNonSuccessResponse } from '$lib/core/fetchHandler';
 import { STORAGE_GOTRUE, STORAGE_ENCRYPTION_SECRET } from '$lib/core/storageKeys';
-import { clearDraft } from '$lib/content/contentDraft';
+import { clearDraft } from '$lib/form/draft';
 import { destroyFetchUserTokenPromise, fetchUserToken, type TokenObject } from './userFetcher';
 
 export interface AuthObject {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,28 +1,18 @@
 <script lang="ts" context="module">
-  import { initTranslation, type TranslationData } from '$lib/i18n/translation';
-  export async function load({ url }) {
-    const p = new URLSearchParams(url.search);
-    const locale = p.get('hl') || 'en';
-    let translationData: TranslationData;
-    switch (locale) {
-      case 'id': {
-        translationData = (await import('$lib/i18n/translationData_id')).translationData;
-        break;
-      }
-      case 'en':
-      default: {
-        translationData = (await import('$lib/i18n/translationData_en')).translationData;
-      }
-    }
-    const tr = initTranslation(translationData);
+  import type { Load } from '@sveltejs/kit';
+  import { getHostLanguageFromSearch, i18n } from '$lib/i18n/i18n';
+  export const load: Load = async function load({ url }) {
+    const hl = getHostLanguageFromSearch(url.search);
+    const { tr, locale } = await i18n(hl);
     return {
       status: 200,
       props: {
         tr,
         locale,
+        url,
       },
     };
-  }
+  };
 </script>
 
 <script lang="ts">
@@ -35,7 +25,10 @@
   import { handleHashVisit } from '$lib/user/auth';
   import { handleQueryVisit } from '$lib/query-string/queryStringHandler';
   import type { TranslationFunction } from '$lib/i18n/translation';
+  import SEO from '$lib/i18n/SEO.svelte';
   export let tr: TranslationFunction;
+  export let locale: string;
+  export let url: URL;
   setContext('tr', tr);
   onMount(async () => {
     try {
@@ -60,6 +53,7 @@
 <svelte:head>
   <title>{tr('title')}</title>
   <meta name="description" content={tr('description')} />
+  <SEO {locale} pathname={url.pathname} />
 </svelte:head>
 <div class="wrapper" style={colorPalette}>
   <Header />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,15 +1,44 @@
+<script lang="ts" context="module">
+  import { initTranslation, type TranslationData } from '$lib/i18n/translation';
+  export async function load() {
+    const locale = 'en';
+    let translationData: TranslationData;
+    switch (locale) {
+      case 'en':
+      default: {
+        translationData = (await import('$lib/i18n/translationData_en')).translationData;
+      }
+    }
+    const tr = initTranslation(translationData);
+    return {
+      status: 200,
+      props: {
+        tr,
+        locale,
+      },
+    };
+  }
+</script>
+
 <script lang="ts">
   import Header from '$lib/core/Header.svelte';
   import Login from '$lib/user/Login.svelte';
   import Footer from '$lib/core/Footer.svelte';
   import { blue, darkGrey, grey, lightGrey } from '$lib/core/colors';
   import Form from '$lib/form/form.svelte';
-  import { onMount } from 'svelte';
+  import { onMount, setContext } from 'svelte';
   import { handleHashVisit } from '$lib/user/auth';
   import { handleQueryVisit } from '$lib/query-string/queryStringHandler';
+  import type { TranslationFunction } from '$lib/i18n/translation';
+  export let tr: TranslationFunction;
+  setContext('tr', tr);
   onMount(async () => {
     try {
-      await handleQueryVisit();
+      await handleQueryVisit(
+        tr('messageExtended'),
+        tr('messageUnsubscribed'),
+        tr('queryActionError'),
+      );
       await handleHashVisit();
     } catch (err) {
       switch (err.message) {
@@ -24,8 +53,8 @@
 </script>
 
 <svelte:head>
-  <title>Sejiwo - Your testament in the cloud</title>
-  <meta name="description" content="Sejiwo is a secure testament storage and delivery service" />
+  <title>{tr('title')}</title>
+  <meta name="description" content={tr('description')} />
 </svelte:head>
 <div class="wrapper" style={colorPalette}>
   <Header />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,9 +1,14 @@
 <script lang="ts" context="module">
   import { initTranslation, type TranslationData } from '$lib/i18n/translation';
-  export async function load() {
-    const locale = 'en';
+  export async function load({ url }) {
+    const p = new URLSearchParams(url.search);
+    const locale = p.get('hl') || 'en';
     let translationData: TranslationData;
     switch (locale) {
+      case 'id': {
+        translationData = (await import('$lib/i18n/translationData_id')).translationData;
+        break;
+      }
       case 'en':
       default: {
         translationData = (await import('$lib/i18n/translationData_en')).translationData;

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -1,0 +1,32 @@
+import test, { expect } from '@playwright/test';
+
+const subheadingEN = 'Testament in the cloud';
+const subheadingID = 'Surat wasiat online';
+
+test('accept-language "en" no redirect', async ({ browser }) => {
+  const context = await browser.newContext({ locale: 'en-US,en;q=0.8' });
+  const page = await context.newPage();
+  await page.goto('/?other=query&still=ok');
+  expect(page.url()).toBe('http://localhost:3000/?other=query&still=ok');
+  expect(await page.locator('div > span').innerText()).toBe(subheadingEN);
+  await page.goto('/?hl=id&other=query&still=ok');
+  expect(page.url()).toBe('http://localhost:3000/?hl=id&other=query&still=ok');
+  expect(await page.locator('div > span').innerText()).toBe(subheadingID);
+  await page.goto('/?hl=xxx&other=query&still=ok');
+  expect(page.url()).toBe('http://localhost:3000/?hl=xxx&other=query&still=ok');
+  expect(await page.locator('div > span').innerText()).toBe(subheadingEN);
+});
+
+test.only('accept-language "id" redirect', async ({ browser }) => {
+  const context = await browser.newContext({ locale: 'th-TH,id-ID;q=0.8' });
+  const page = await context.newPage();
+  await page.goto('/?other=query&still=ok');
+  expect(page.url()).toBe('http://localhost:3000/?other=query&still=ok&hl=id');
+  expect(await page.locator('div > span').innerText()).toBe(subheadingID);
+  await page.goto('/?hl=en&other=query&still=ok');
+  expect(page.url()).toBe('http://localhost:3000/?hl=en&other=query&still=ok');
+  expect(await page.locator('div > span').innerText()).toBe(subheadingEN);
+  await page.goto('/?hl=xxx&other=query&still=ok');
+  expect(page.url()).toBe('http://localhost:3000/?hl=xxx&other=query&still=ok');
+  expect(await page.locator('div > span').innerText()).toBe(subheadingEN);
+});


### PR DESCRIPTION
Add i18n using `hl` query string.
Currently supports http://localhost:3000/?hl=en & http://localhost:3000/?hl=id (default to en)

- [x] Create translation system
- [x] Extract English translation 
- [x] Translate to Bahasa Indonesia
- [x] Detect language preference
- [x] Browser test